### PR TITLE
Webpack設定の更新

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,10 @@
             "alias": {
                 "extensions": [".js", ".jsx", ".ts", ".tsx"],
                 /** エイリアスを増やす場合は、webpack.config.js, tsconfig.paths.json, .eslintrc.json の3つのファイルの変更が必要です */
-                "map": [["@", "./react-src/ts"]]
+                "map": [
+                    ["@ts", "./react-src/ts"],
+                    ["@sass", "./react-src/sass"]
+                ]
             }
         }
     }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -3,7 +3,8 @@
         "baseUrl": ".",
         "paths": {
             /** エイリアスを増やす場合は、webpack.config.js, tsconfig.paths.json, .eslintrc.json の3つのファイルの変更が必要です */
-            "@/*": ["./react-src/ts/*"]
+            "@ts/*": ["./react-src/ts/*"],
+            "@sass/*": ["./react-src/sass/*"]
         }
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ const path = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const webpack = require("webpack");
 
+const version = process.env.MIX_GITHUB_SHA || "development";
+
 /** Laravelのwebpack.mix.jsで扱うためにエクスポート */
 module.exports = {
     plugins: [
@@ -21,7 +23,7 @@ module.exports = {
             ],
         }),
     ],
-    output: { publicPath: "" },
+    output: { chunkFilename: "js/chunks/" + version + ".[id].js" },
     module: {
         rules: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
         extensions: [".ts", ".tsx"],
         alias: {
             /** エイリアスを増やす場合は、webpack.config.js, tsconfig.paths.json, .eslintrc.json の3つのファイルの変更が必要です */
-            "@": path.resolve(__dirname, "react-src/ts/"),
+            "@ts": path.resolve(__dirname, "react-src/ts/"),
+            "@sass": path.resolve(__dirname, "react-src/sass/"),
         },
     },
 };

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -2,7 +2,7 @@ const mix = require("laravel-mix");
 const glob = require("glob");
 const productionSourceMaps = false;
 
-const version = process.env.MIX_GITHUB_SHA ?? "development";
+const version = process.env.MIX_GITHUB_SHA || "development";
 
 /** webpack.config.jsで定義されているwebpackの設定 */
 const config = require("./webpack.config");
@@ -13,7 +13,7 @@ const indexJsName = "public/js/" + version + ".js";
 /** CSSのファイル名規則 */
 const mainCssName = "public/css/" + version + ".css";
 
-mix.ts("react-src/ts/index.tsx", indexJsName)
+mix.ts("react-src/ts/", indexJsName)
     .sourceMaps(productionSourceMaps, "eval-source-map")
     .options({
         terser: {
@@ -25,24 +25,23 @@ mix.ts("react-src/ts/index.tsx", indexJsName)
         },
     })
     .sass("react-src/sass/style.scss", mainCssName)
-    .webpackConfig(config);
-
-mix.browserSync({
-    https: {
-        key: "certs/server.key",
-        cert: "certs/server.crt",
-    },
-    port: 443,
-    proxy: {
-        target: "http://nginx",
-        proxyReq: [
-            function (proxyReq) {
-                proxyReq.setHeader("HOST", "localhost");
-                proxyReq.setHeader("X-Forwarded-Proto", "https");
-            },
-        ],
-    },
-    open: false,
-    reloadOnRestart: true,
-    files: ["react-src/sass/**/*.scss", "react-src/ts/**/*.*"],
-});
+    .webpackConfig(config)
+    .browserSync({
+        https: {
+            key: "certs/server.key",
+            cert: "certs/server.crt",
+        },
+        port: 443,
+        proxy: {
+            target: "http://nginx",
+            proxyReq: [
+                function (proxyReq) {
+                    proxyReq.setHeader("HOST", "localhost");
+                    proxyReq.setHeader("X-Forwarded-Proto", "https");
+                },
+            ],
+        },
+        open: false,
+        reloadOnRestart: true,
+        files: ["react-src/sass/**/*.scss", "react-src/ts/**/*.*"],
+    });


### PR DESCRIPTION
## この PR の内容

-  `@Sass`エイリアスを追加。それに伴い、TSのディレクトリのエイリアスを`@`から`@ts`に変更
- lazyなどを使い、チャンクを分けた時に専用ディレクトリ内に出力されるように設定を追加

## ユーザーができるようになること

上記の通り

## ユーザーができなくなること

- `@`一時文字だけでのエイリアスを使った`import`はできなくなる

## 動作確認

- Windows10 20H2
- VSCode
- WSL2
- Remote-Containers

上記開発環境で動作確認


